### PR TITLE
#1: Fix factory hooks copy path

### DIFF
--- a/src/Blt/Plugin/Commands/AcsfRecipesCommand.php
+++ b/src/Blt/Plugin/Commands/AcsfRecipesCommand.php
@@ -96,7 +96,7 @@ class AcsfRecipesCommand extends BltTasks {
    * @aliases raih
    */
   public function acsfHooksInitialize() {
-    $defaultAcsfHooks = $this->getConfigValue('blt.root') . '../blt-acsf/factory-hooks';
+    $defaultAcsfHooks = $this->getConfigValue('blt.root') . '/../blt-acsf/factory-hooks';
     $projectAcsfHooks = $this->getConfigValue('repo.root') . '/factory-hooks';
 
     $result = $this->taskCopyDir([$defaultAcsfHooks => $projectAcsfHooks])


### PR DESCRIPTION
Adds a directory separator, which seems to be the problem.
Even if not happening on some environments, worst case any *nix would ignore a double `//`, so it should be safe.