### PR TITLE
Fix multiple addition of acsf module for local uninstallation on running blt acsf:init

### DIFF
--- a/src/Blt/Plugin/Commands/AcsfRecipesCommand.php
+++ b/src/Blt/Plugin/Commands/AcsfRecipesCommand.php
@@ -44,7 +44,10 @@ class AcsfRecipesCommand extends BltTasks {
     $project_yml = $this->getConfigValue('blt.config-files.project');
     $project_config = YamlMunge::parseFile($project_yml);
     if (!empty($project_config['modules'])) {
-      $project_config['modules']['local']['uninstall'][] = 'acsf';
+      // Uninstall acsf module from local if not already added.
+      if (!isset($project_config['modules']['local']['uninstall']) || !in_array('acsf', $project_config['modules']['local']['uninstall'])) {
+        $project_config['modules']['local']['uninstall'][] = 'acsf';
+      }
     }
     YamlMunge::writeFile($project_yml, $project_config);
   }


### PR DESCRIPTION
# Issue:
- Running `acsf:init` multiple times will keep on adding multiple occurances of `acsf` module for local uninstallation in `blt.yml` file

# Resolution:
- Simple condition added to check beforehand
- If `uninstall` key not added in `blt.yml`, then only proceed
- If `uninstall` key added but no mention of `acsf` module, then only proceed