### PR TITLE
Provide a new init command to leverage .acsfstageignore feature.

### DIFF
--- a/.acsfstageignore
+++ b/.acsfstageignore
@@ -1,0 +1,3 @@
+files/styles
+files/css
+files/js

--- a/src/Blt/Plugin/Commands/AcsfRecipesCommand.php
+++ b/src/Blt/Plugin/Commands/AcsfRecipesCommand.php
@@ -41,6 +41,7 @@ class AcsfRecipesCommand extends BltTasks {
     $this->acsfHooksInitialize();
     $this->acsfComposerInitialize();
     $this->acsfDrushInitialize();
+    $this->acsfFilesStageIgnoreInitialize();
     $project_yml = $this->getConfigValue('blt.config-files.project');
     $project_config = YamlMunge::parseFile($project_yml);
     if (!empty($project_config['modules'])) {
@@ -116,4 +117,34 @@ class AcsfRecipesCommand extends BltTasks {
     return $result;
   }
 
+    /**
+   * Creates ".acsfstageignore" file in project's repo root.
+   *
+   * @command recipes:acsf:init:stage-ignore
+   * @aliases raisi
+   */
+  public function acsfFilesStageIgnoreInitialize() {
+    $destination_file = $this->getConfigValue('repo.root') . '/.acsfstageignore';
+    if (file_exists($destination_file)) {
+      $this->say('<info>".acsfstageignore" file already exists in repo root.</info>');
+
+      return TRUE;
+    }
+
+    $template_file = $this->getConfigValue('blt.root') . '/../blt-acsf/.acsfstageignore';
+
+    $result = $this->taskFilesystemStack()
+      ->copy($template_file, $destination_file, TRUE)
+      ->stopOnFail()
+      ->setVerbosityThreshold(VerbosityThresholdInterface::VERBOSITY_VERBOSE)
+      ->run();
+
+    if (!$result->wasSuccessful()) {
+      throw new BltException("Unable to copy .acsfstageignore file.");
+    }
+
+    $this->say('New ".acsfstageignore" file created in repo root. Please commit this to your project.');
+
+    return $result;
+  }
 }


### PR DESCRIPTION
This provides a new init command which copies a default .acsfstageignore file into project root directory.

The ignored files are Drupal's generated and can be regenerated on staged environment.

[docs.acquia.com/site-factory/workflow/staging/skip-files-staging](https://docs.acquia.com/site-factory/workflow/staging/skip-files-staging/)